### PR TITLE
using the minimum set of exceptions

### DIFF
--- a/src/main/java/com/clickntap/vimeo/Vimeo.java
+++ b/src/main/java/com/clickntap/vimeo/Vimeo.java
@@ -1,23 +1,32 @@
 package com.clickntap.vimeo;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.json.JSONObject;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Vimeo {
     private static final String VIMEO_SERVER = "https://api.vimeo.com";
@@ -33,11 +42,11 @@ public class Vimeo {
         this.tokenType = tokenType;
     }
 
-    public VimeoResponse getVideoInfo(String videoEndpoint) throws Exception {
+    public VimeoResponse getVideoInfo(String videoEndpoint) throws IOException {
         return apiRequest(videoEndpoint, HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse updateVideoMetadata(String videoEndpoint, String name, String description, String license, String privacyView, String privacyEmbed, boolean reviewLink) throws Exception {
+    public VimeoResponse updateVideoMetadata(String videoEndpoint, String name, String description, String license, String privacyView, String privacyEmbed, boolean reviewLink) throws IOException {
         Map<String, String> params = new HashMap<String, String>();
         params.put("name", name);
         params.put("description", description);
@@ -48,44 +57,44 @@ public class Vimeo {
         return apiRequest(videoEndpoint, HttpPatch.METHOD_NAME, params, null);
     }
 
-    public VimeoResponse addVideoPrivacyDomain(String videoEndpoint, String domain) throws Exception {
+    public VimeoResponse addVideoPrivacyDomain(String videoEndpoint, String domain) throws ClientProtocolException, UnsupportedEncodingException, IOException {
         return apiRequest(new StringBuffer(videoEndpoint).append("/privacy/domains/").append(URLEncoder.encode(domain, "UTF-8")).toString(), HttpPut.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse getVideoPrivacyDomains(String videoEndpoint) throws Exception {
+    public VimeoResponse getVideoPrivacyDomains(String videoEndpoint) throws IOException {
         return apiRequest(new StringBuffer(videoEndpoint).append("/privacy/domains").toString(), HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse removeVideo(String videoEndpoint) throws Exception {
+    public VimeoResponse removeVideo(String videoEndpoint) throws IOException {
         return apiRequest(videoEndpoint, HttpDelete.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse getVideos() throws Exception {
+    public VimeoResponse getVideos() throws IOException {
         return apiRequest("/me/videos", HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse searchVideos(String query) throws Exception {
+    public VimeoResponse searchVideos(String query) throws IOException {
         return apiRequest("/me/videos?query=" + query, HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse searchVideos(String query, String pageNumber, String itemsPerPage) throws Exception {
+    public VimeoResponse searchVideos(String query, String pageNumber, String itemsPerPage) throws IOException {
         String apiRequestEndpoint = "/me/videos?page=" + pageNumber + "&per_page=" + itemsPerPage + "&query=" + query;
         return apiRequest(apiRequestEndpoint, HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse beginUploadVideo(Map<String, String> params) throws Exception {
+    public VimeoResponse beginUploadVideo(Map<String, String> params) throws IOException {
         return apiRequest("/me/videos", HttpPost.METHOD_NAME, params, null);
     }
 
-    public VimeoResponse uploadVideo(File file, String uploadLinkSecure) throws Exception {
+    public VimeoResponse uploadVideo(File file, String uploadLinkSecure) throws IOException {
         return apiRequest(uploadLinkSecure, HttpPut.METHOD_NAME, null, file);
     }
 
-    public VimeoResponse endUploadVideo(String completeUri) throws Exception {
+    public VimeoResponse endUploadVideo(String completeUri) throws IOException {
         return apiRequest(completeUri, HttpDelete.METHOD_NAME, null, null);
     }
 
-    public String addVideo(File file, boolean upgradeTo1080) throws Exception {
+    public String addVideo(File file, boolean upgradeTo1080) throws IOException, VimeoException {
         Map<String, String> params = new HashMap<String, String>();
         params.put("type", "streaming");
         params.put("redirect_url", "");
@@ -105,39 +114,39 @@ public class Vimeo {
             throw new VimeoException(new StringBuffer("HTTP Status Code: ").append(response.getStatusCode()).toString());
     }
 
-    public VimeoResponse likesVideo(String videoId) throws Exception {
+    public VimeoResponse likesVideo(String videoId) throws IOException {
         return apiRequest(new StringBuffer("/me/likes/").append(videoId).toString(), HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse likeVideo(String videoId) throws Exception {
+    public VimeoResponse likeVideo(String videoId) throws IOException {
         return apiRequest(new StringBuffer("/me/likes/").append(videoId).toString(), HttpPut.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse unlikeVideo(String videoId) throws Exception {
+    public VimeoResponse unlikeVideo(String videoId) throws IOException {
         return apiRequest(new StringBuffer("/me/likes/").append(videoId).toString(), HttpDelete.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse checkEmbedPreset(String videoEndPoint, String presetId) throws Exception {
+    public VimeoResponse checkEmbedPreset(String videoEndPoint, String presetId) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/presets/").append(presetId).toString(), HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse addEmbedPreset(String videoEndPoint, String presetId) throws Exception {
+    public VimeoResponse addEmbedPreset(String videoEndPoint, String presetId) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/presets/").append(presetId).toString(), HttpPut.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse removeEmbedPreset(String videoEndPoint, String presetId) throws Exception {
+    public VimeoResponse removeEmbedPreset(String videoEndPoint, String presetId) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/presets/").append(presetId).toString(), HttpDelete.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse getTextTracks(String videoEndPoint) throws Exception {
+    public VimeoResponse getTextTracks(String videoEndPoint) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/texttracks").toString(), HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse getTextTrack(String videoEndPoint, String textTrackId) throws Exception {
+    public VimeoResponse getTextTrack(String videoEndPoint, String textTrackId) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/texttracks/").append(textTrackId).toString(), HttpGet.METHOD_NAME, null, null);
     }
 
-    public String addTextTrack(String videoEndPoint, File file, boolean active, String type, String language, String name) throws Exception {
+    public String addTextTrack(String videoEndPoint, File file, boolean active, String type, String language, String name) throws IOException, VimeoException {
 
         String textTrackEndPoint = null;
         VimeoResponse response = null;
@@ -166,7 +175,7 @@ public class Vimeo {
 
     }
 
-    public VimeoResponse updateTextTrack(String videoEndPoint, String textTrackUri, boolean active, String type, String language, String name) throws Exception {
+    public VimeoResponse updateTextTrack(String videoEndPoint, String textTrackUri, boolean active, String type, String language, String name) throws IOException {
         Map<String, String> params = new HashMap<String, String>();
         params.put("active", active ? "true" : "false");
         params.put("type", type);
@@ -175,11 +184,11 @@ public class Vimeo {
         return apiRequest(new StringBuffer(videoEndPoint).append(textTrackUri).toString(), HttpPatch.METHOD_NAME, params, null);
     }
 
-    public VimeoResponse removeTextTrack(String videoEndPoint, String textTrackId) throws Exception {
+    public VimeoResponse removeTextTrack(String videoEndPoint, String textTrackId) throws IOException {
         return apiRequest(new StringBuffer(videoEndPoint).append("/texttracks/").append(textTrackId).toString(), HttpDelete.METHOD_NAME, null, null);
     }
 
-    private VimeoResponse apiRequest(String endpoint, String methodName, Map<String, String> params, File file) throws Exception {
+    private VimeoResponse apiRequest(String endpoint, String methodName, Map<String, String> params, File file) throws IOException {
         CloseableHttpClient client = HttpClientBuilder.create().build();
         HttpRequestBase request = null;
         String url = null;


### PR DESCRIPTION
Hey guys,

I've changed the "throws Exception" into "throws IOException" since all (but 2) cases only throws IOException. That allows end users to decide if they want to catch everything or just IO.

In those two situations where IOException and ClientException are both required, they are both there.

The code is backward compatible, of course.