### PR TITLE
/oauth/verify endpoint and update to updateVideoMetadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.clickntap</groupId>
 	<artifactId>vimeo</artifactId>
-	<version>1.5.1-SNAPSHOT</version>
+	<version>1.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Vimeo</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.clickntap</groupId>
 	<artifactId>vimeo</artifactId>
-	<version>1.5-SNAPSHOT</version>
+	<version>1.5.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Vimeo</name>

--- a/src/main/java/com/clickntap/vimeo/Vimeo.java
+++ b/src/main/java/com/clickntap/vimeo/Vimeo.java
@@ -46,14 +46,14 @@ public class Vimeo {
         return apiRequest(videoEndpoint, HttpGet.METHOD_NAME, null, null);
     }
 
-    public VimeoResponse updateVideoMetadata(String videoEndpoint, String name, String description, String license, String privacyView, String privacyEmbed, boolean reviewLink) throws IOException {
+    public VimeoResponse updateVideoMetadata(String videoEndpoint, String name, String description, String license, String privacyView, String privacyEmbed, Boolean reviewLink) throws IOException {
         Map<String, String> params = new HashMap<String, String>();
-        params.put("name", name);
-        params.put("description", description);
-        params.put("license", license);
-        params.put("privacy.view", privacyView);
-        params.put("privacy.embed", privacyEmbed);
-        params.put("review_link", reviewLink ? "true" : "false");
+        if ( name != null ) params.put("name", name);
+        if ( description != null ) params.put("description", description);
+        if ( license != null ) params.put("license", license);
+        if ( privacyView != null ) params.put("privacy.view", privacyView);
+        if ( privacyEmbed != null ) params.put("privacy.embed", privacyEmbed);
+        if ( reviewLink != null ) params.put("review_link", reviewLink ? "true" : "false");
         return apiRequest(videoEndpoint, HttpPatch.METHOD_NAME, params, null);
     }
 
@@ -71,6 +71,10 @@ public class Vimeo {
 
     public VimeoResponse getMe() throws IOException {
         return apiRequest("/me", HttpGet.METHOD_NAME, null, null);
+    }
+
+    public VimeoResponse getOauthVerify() throws IOException {
+        return apiRequest("/oauth/verify", HttpGet.METHOD_NAME, null, null);
     }
 
     public VimeoResponse getVideos() throws IOException {


### PR DESCRIPTION
Added `getOauthVerify()` method to allow checking for users' scopes

Made each field in `updateVideoMetadata()` optional. If a value is null, it is not added to the parameter list.