### PR TITLE
Added support for InputStream and byte[] data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.clickntap</groupId>
+	<groupId>cc.protea.foundation</groupId>
 	<artifactId>vimeo</artifactId>
 	<version>1.11-SNAPSHOT</version>
 	<packaging>jar</packaging>

--- a/src/main/java/com/clickntap/vimeo/Vimeo.java
+++ b/src/main/java/com/clickntap/vimeo/Vimeo.java
@@ -1,8 +1,11 @@
 package com.clickntap.vimeo;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -22,7 +25,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -123,7 +126,15 @@ public class Vimeo {
 	}
 
 	public VimeoResponse uploadVideo(File file, String uploadLinkSecure) throws IOException {
-		return apiRequest(uploadLinkSecure, HttpPut.METHOD_NAME, null, file);
+		return uploadVideo(new FileInputStream(file), uploadLinkSecure);
+	}
+	
+	public VimeoResponse uploadVideo(byte[] bytes, String uploadLinkSecure) throws IOException {
+		return uploadVideo(new ByteArrayInputStream(bytes), uploadLinkSecure);
+	}
+	
+	public VimeoResponse uploadVideo(InputStream inputStream, String uploadLinkSecure) throws IOException {
+		return apiRequest(uploadLinkSecure, HttpPut.METHOD_NAME, null, inputStream);
 	}
 
 	public VimeoResponse endUploadVideo(String completeUri) throws IOException {
@@ -131,13 +142,21 @@ public class Vimeo {
 	}
 
 	public String addVideo(File file, boolean upgradeTo1080) throws IOException, VimeoException {
+		return addVideo(new FileInputStream(file), upgradeTo1080);
+	}
+	
+	public String addVideo(byte[] bytes, boolean upgradeTo1080) throws IOException, VimeoException {
+		return addVideo(new ByteArrayInputStream(bytes), upgradeTo1080);
+	}
+	
+	public String addVideo(InputStream inputStream, boolean upgradeTo1080) throws IOException, VimeoException {
 		Map<String, String> params = new HashMap<String, String>();
 		params.put("type", "streaming");
 		params.put("redirect_url", "");
 		params.put("upgrade_to_1080", upgradeTo1080 ? "true" : "false");
 		VimeoResponse response = beginUploadVideo(params);
 		if (response.getStatusCode() == 201) {
-			uploadVideo(file, response.getJson().getString("upload_link_secure"));
+			uploadVideo(inputStream, response.getJson().getString("upload_link_secure"));
 			response = endUploadVideo(response.getJson().getString("complete_uri"));
 			if (response.getStatusCode() == 201) {
 				return response.getJson().getString("Location");
@@ -179,6 +198,14 @@ public class Vimeo {
 	}
 
 	public String addTextTrack(String videoEndPoint, File file, boolean active, String type, String language, String name) throws IOException, VimeoException {
+		return addTextTrack(videoEndPoint, new FileInputStream(file), active, type, language, name);
+	}
+	
+	public String addTextTrack(String videoEndPoint, byte[] bytes, boolean active, String type, String language, String name) throws IOException, VimeoException {
+		return addTextTrack(videoEndPoint, new ByteArrayInputStream(bytes), active, type, language, name);
+	}
+
+	public String addTextTrack(String videoEndPoint, InputStream inputStream, boolean active, String type, String language, String name) throws IOException, VimeoException {
 
 		VimeoResponse response = null;
 
@@ -192,7 +219,7 @@ public class Vimeo {
 
 		if (addVideoRespose.getStatusCode() == 201) {
 			String textTrackUploadLink = addVideoRespose.getJson().getString("link");
-			response = apiRequest(textTrackUploadLink, HttpPut.METHOD_NAME, null, file);
+			response = apiRequest(textTrackUploadLink, HttpPut.METHOD_NAME, null, inputStream);
 			if (response.getStatusCode() == 200) {
 				return addVideoRespose.getJson().getString("uri");
 			}
@@ -214,7 +241,7 @@ public class Vimeo {
 		return apiRequest(new StringBuffer(videoEndPoint).append("/texttracks/").append(textTrackId).toString(), HttpDelete.METHOD_NAME, null, null);
 	}
 
-	protected VimeoResponse apiRequest(String endpoint, String methodName, Map<String, String> params, File file) throws IOException {
+	protected VimeoResponse apiRequest(String endpoint, String methodName, Map<String, String> params, InputStream inputStream) throws IOException {
 		CloseableHttpClient client = HttpClientBuilder.create().build();
 		HttpRequestBase request = null;
 		String url = null;
@@ -243,8 +270,8 @@ public class Vimeo {
 				postParameters.add(new BasicNameValuePair(key, params.get(key)));
 			}
 			entity = new UrlEncodedFormEntity(postParameters);
-		} else if (file != null) {
-			entity = new FileEntity(file, ContentType.MULTIPART_FORM_DATA);
+		} else if (inputStream != null) {
+			entity = new InputStreamEntity(inputStream, ContentType.MULTIPART_FORM_DATA);
 		}
 		if (entity != null) {
 			if (request instanceof HttpPost) {


### PR DESCRIPTION
Hi! Very helpful library but using java.io.File to hold data requires sdk users to write files to disk before uploading to Vimeo. This is impractical in some virtual environments and requires cleanup of temporary files so frequently it is preferable to keep data in memory.

I've updated the sdk to use the more flexible InputStreamEntity and provided methods allowing users to add videos as byte[] or InputStream in addition to File.  This change is completely backwards compatible and integrations using java.io.File continue to work just like before. 

Thanks!
Loren